### PR TITLE
CI: Fix lint and test program jobs

### DIFF
--- a/program/Cargo.toml
+++ b/program/Cargo.toml
@@ -2,7 +2,7 @@
 name = "spl-token-metadata-example"
 version = "0.3.0"
 description = "Solana Program Library Token Metadata Example Program"
-documentation = "https://docs.rs/spl-token-group-interface"
+documentation = "https://docs.rs/spl-token-metadata-example"
 authors = { workspace = true }
 repository = { workspace = true }
 homepage = { workspace = true }

--- a/program/tests/program_test.rs
+++ b/program/tests/program_test.rs
@@ -34,7 +34,7 @@ pub async fn setup(
     let mut program_test = ProgramTest::new(
         "spl_token_metadata_example",
         *program_id,
-        processor!(spl_token_metadata_example::processor::process),
+        None,
     );
 
     program_test.prefer_bpf(false); // simplicity in the build

--- a/program/tests/program_test.rs
+++ b/program/tests/program_test.rs
@@ -31,11 +31,7 @@ pub async fn setup(
     Arc<dyn ProgramClient<ProgramBanksClientProcessTransaction>>,
     Arc<Keypair>,
 ) {
-    let mut program_test = ProgramTest::new(
-        "spl_token_metadata_example",
-        *program_id,
-        None,
-    );
+    let mut program_test = ProgramTest::new("spl_token_metadata_example", *program_id, None);
 
     program_test.prefer_bpf(false); // simplicity in the build
     program_test.add_program(


### PR DESCRIPTION
#### Problem

We made spl-token-metadata-example purely a cdylib in #3, but the tests were using it as a library.

#### Summary of changes

That code wasn't being used anyway, so force the test to use the built BPF program.

Also clean up some other stuff.