### PR TITLE
fix(interface): validate Borsh string lengths in unpack() to prevent SBF heap abort

### DIFF
--- a/interface/src/instruction.rs
+++ b/interface/src/instruction.rs
@@ -167,6 +167,30 @@ pub enum TokenMetadataInstruction {
     ///   0. `[]` Metadata account
     Emit(Emit),
 }
+/// Validates that a Borsh-encoded `String` starting at `*cursor` declares a
+/// length that fits within `rest`, advancing `*cursor` past it on success.
+///
+/// `TokenMetadataInstruction::unpack` calls this before `try_from_slice` so a
+/// forged length prefix can't trigger an oversized allocation that aborts on
+/// the SBF heap. See <https://github.com/solana-program/token-2022/issues/1152>.
+fn check_borsh_string(rest: &[u8], cursor: &mut usize) -> Result<(), ProgramError> {
+    let len_end = cursor
+        .checked_add(core::mem::size_of::<u32>())
+        .ok_or(ProgramError::InvalidInstructionData)?;
+    let len_bytes = rest
+        .get(*cursor..len_end)
+        .ok_or(ProgramError::InvalidInstructionData)?;
+    let len = u32::from_le_bytes(len_bytes.try_into().unwrap()) as usize;
+    let str_end = len_end
+        .checked_add(len)
+        .ok_or(ProgramError::InvalidInstructionData)?;
+    if str_end > rest.len() {
+        return Err(ProgramError::InvalidInstructionData);
+    }
+    *cursor = str_end;
+    Ok(())
+}
+
 impl TokenMetadataInstruction {
     /// Unpacks a byte buffer into a
     /// [`TokenMetadataInstruction`](enum.TokenMetadataInstruction.html).
@@ -177,14 +201,33 @@ impl TokenMetadataInstruction {
         let (discriminator, rest) = input.split_at(ArrayDiscriminator::LENGTH);
         Ok(match discriminator {
             Initialize::SPL_DISCRIMINATOR_SLICE => {
+                let mut cursor = 0usize;
+                check_borsh_string(rest, &mut cursor)?; // name
+                check_borsh_string(rest, &mut cursor)?; // symbol
+                check_borsh_string(rest, &mut cursor)?; // uri
                 let data = Initialize::try_from_slice(rest)?;
                 Self::Initialize(data)
             }
             UpdateField::SPL_DISCRIMINATOR_SLICE => {
+                let mut cursor = 0usize;
+                // `Field` is a Borsh enum: 1-byte variant tag, and only the
+                // `Key` variant (tag 3) carries a nested string.
+                let tag = *rest
+                    .get(cursor)
+                    .ok_or(ProgramError::InvalidInstructionData)?;
+                cursor = cursor
+                    .checked_add(1)
+                    .ok_or(ProgramError::InvalidInstructionData)?;
+                if tag == 3 {
+                    check_borsh_string(rest, &mut cursor)?; // Field::Key(String)
+                }
+                check_borsh_string(rest, &mut cursor)?; // value
                 let data = UpdateField::try_from_slice(rest)?;
                 Self::UpdateField(data)
             }
             RemoveKey::SPL_DISCRIMINATOR_SLICE => {
+                let mut cursor = 1usize; // skip the 1-byte `idempotent` bool
+                check_borsh_string(rest, &mut cursor)?; // key
                 let data = RemoveKey::try_from_slice(rest)?;
                 Self::RemoveKey(data)
             }
@@ -414,6 +457,41 @@ mod test {
         let preimage = hashv(&[format!("{NAMESPACE}:emitter").as_bytes()]);
         let discriminator = &preimage.as_ref()[..ArrayDiscriminator::LENGTH];
         check_pack_unpack(check, discriminator, data);
+    }
+
+    #[test]
+    fn fail_unpack_initialize_with_forged_name_length() {
+        let mut input = vec![];
+        input.extend_from_slice(Initialize::SPL_DISCRIMINATOR_SLICE);
+        input.extend_from_slice(&u32::MAX.to_le_bytes()); // forged name length, no bytes follow
+        assert_eq!(
+            TokenMetadataInstruction::unpack(&input).unwrap_err(),
+            ProgramError::InvalidInstructionData,
+        );
+    }
+
+    #[test]
+    fn fail_unpack_update_field_with_forged_value_length() {
+        let mut input = vec![];
+        input.extend_from_slice(UpdateField::SPL_DISCRIMINATOR_SLICE);
+        input.push(0u8); // Field::Name (tag 0, no nested string)
+        input.extend_from_slice(&u32::MAX.to_le_bytes()); // forged value length
+        assert_eq!(
+            TokenMetadataInstruction::unpack(&input).unwrap_err(),
+            ProgramError::InvalidInstructionData,
+        );
+    }
+
+    #[test]
+    fn fail_unpack_remove_key_with_forged_key_length() {
+        let mut input = vec![];
+        input.extend_from_slice(RemoveKey::SPL_DISCRIMINATOR_SLICE);
+        input.push(0u8); // idempotent = false
+        input.extend_from_slice(&u32::MAX.to_le_bytes()); // forged key length
+        assert_eq!(
+            TokenMetadataInstruction::unpack(&input).unwrap_err(),
+            ProgramError::InvalidInstructionData,
+        );
     }
 
     #[cfg(feature = "serde-traits")]

--- a/scripts/solana.dic
+++ b/scripts/solana.dic
@@ -61,3 +61,5 @@ Pedersen
 aes
 plaintext
 pausable
+oversized
+SBF


### PR DESCRIPTION
## Problem

`TokenMetadataInstruction::unpack()` calls `try_from_slice(rest)?` directly on attacker-controlled instruction data. A Borsh `String` is a little-endian `u32` length prefix followed by that many bytes, so a forged prefix like `u32::MAX` makes Borsh try to allocate ~1 MiB before the `?` error path runs and discovers the buffer is too short. On the 32 KiB SBF heap that allocation aborts the program instead of returning a clean error.

Only the variants that carry Borsh strings are affected: `Initialize` (name, symbol, uri), `UpdateField` (the `value` string, plus the nested string in `Field::Key`, tag 3), and `RemoveKey` (the `key` string after the `idempotent` bool). `UpdateAuthority` and `Emit` have no strings and are left alone.

## Fix

A new `check_borsh_string` helper reads each string's declared length and checks it against the remaining buffer before `try_from_slice` runs, returning `InvalidInstructionData` when it doesn't fit. The three affected match arms walk a cursor through their fields and validate each string first. The length arithmetic is checked so it can't overflow.

## Tests

Three tests feed a forged `u32::MAX` length prefix through `unpack()` for `Initialize`, `UpdateField`, and `RemoveKey` and assert `InvalidInstructionData`. They run natively, no SBF build needed. They also work as real regression guards: before the fix Borsh returns a different (IO) error, so the assertion would fail.

## Context

This puts the validation in `spl-token-metadata-interface`, where the data is deserialized, rather than in the token-2022 caller. It follows the discussion on solana-program/token-2022#1194 (now closed), where @joncinque suggested the fix should live here. References solana-program/token-2022#1152. The token-2022 side is then just a dependency bump once this releases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)