### PR TITLE
build(js-legacy): upgrade TypeScript to 6.0

### DIFF
--- a/clients/js-legacy/package.json
+++ b/clients/js-legacy/package.json
@@ -72,7 +72,7 @@
         "ts-node": "^10.9.2",
         "tslib": "^2.8.1",
         "typedoc": "^0.28.19",
-        "typescript": "^5.7.2"
+        "typescript": "^6.0.3"
     },
     "prettier": "@solana/prettier-config-solana"
 }

--- a/clients/js-legacy/tsconfig.base.json
+++ b/clients/js-legacy/tsconfig.base.json
@@ -3,7 +3,10 @@
     "compilerOptions": {
         "target": "ESNext",
         "module": "ESNext",
-        "moduleResolution": "Node",
+        "moduleResolution": "node10",
+        "ignoreDeprecations": "6.0",
+        "lib": ["ES2020", "DOM"],
+        "types": ["node"],
         "esModuleInterop": true,
         "isolatedModules": true,
         "noEmitOnError": true,

--- a/clients/js-legacy/tsconfig.cjs.json
+++ b/clients/js-legacy/tsconfig.cjs.json
@@ -2,6 +2,7 @@
     "extends": "./tsconfig.base.json",
     "include": ["src"],
     "compilerOptions": {
+        "rootDir": "./src",
         "outDir": "lib/cjs",
         "target": "ES2016",
         "module": "CommonJS",

--- a/clients/js-legacy/tsconfig.esm.json
+++ b/clients/js-legacy/tsconfig.esm.json
@@ -2,6 +2,7 @@
     "extends": "./tsconfig.base.json",
     "include": ["src"],
     "compilerOptions": {
+        "rootDir": "./src",
         "outDir": "lib/esm",
         "declarationDir": "lib/types",
         "target": "ES2020",

--- a/clients/js-legacy/tsconfig.json
+++ b/clients/js-legacy/tsconfig.json
@@ -3,6 +3,7 @@
     "include": ["src", "test"],
     "compilerOptions": {
         "noEmit": true,
-        "skipLibCheck": true
+        "skipLibCheck": true,
+        "types": ["node", "mocha"]
     }
 }


### PR DESCRIPTION
Upgrades the `js-legacy` client to TypeScript 6.0.

## Changes
- Bump `typescript` to `^6.0.3`.
- `tsconfig.base.json`: set `moduleResolution` to `node10` (the `Node` alias was removed in TS6), add `ignoreDeprecations: "6.0"`, and pin `lib`/`types` explicitly so the default lib set is unaffected.
- `tsconfig.cjs.json` / `tsconfig.esm.json`: add `rootDir: "./src"`.
- `tsconfig.json`: add `mocha` to `types`.

Note: there is also an open Dependabot branch (`dependabot/npm_and_yarn/clients/js-legacy/typescript-6.0.3`) doing the version bump; this PR additionally carries the tsconfig adjustments needed for the build to pass under TS6.